### PR TITLE
Upgrade (except windows) to 5.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 env:
   global:
     - CONAN_UPLOAD=1
-    - CONAN_REFERENCE="giflib/5.1.2"
+    - CONAN_REFERENCE="giflib/5.1.3"
     - CONAN_USERNAME="lasote"
     - CONAN_CHANNEL="ci"
     - CONAN_TOTAL_PAGES=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     PYTHON_ARCH: "32"
     
     CONAN_UPLOAD: 1
-    CONAN_REFERENCE: "giflib/5.1.2"
+    CONAN_REFERENCE: "giflib/5.1.3"
     CONAN_USERNAME: "lasote"
     CONAN_CHANNEL: "ci"
     CONAN_TOTAL_PAGES: 4

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,13 +6,13 @@ from conans import CMake, ConfigureEnvironment
 
 class ZlibNgConan(ConanFile):
     name = "giflib"
-    version = "5.1.2"
+    version = "5.1.3"
     ZIP_FOLDER_NAME = "giflib-%s" % version 
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = "shared=False", "fPIC=True"
-    url="http://github.com/lasote/conan-zlib-ng"
+    url="http://github.com/lasote/conan-giflib"
     license="https://sourceforge.net/p/giflib/code/ci/master/tree/COPYING"
     exports = ["FindGIF.cmake", "CMakeLists.txt", "getopt.c", "getopt.h", "stdbool.h", "unistd.h.in", "giflib-%s-windows.zip" % version]
     # The exported files I took them from https://github.com/bjornblissing/osg-3rdparty-cmake/tree/master/giflib

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -16,7 +16,7 @@ class DefaultNameConan(ConanFile):
     version = "0.1"
     settings = "os", "compiler", "arch", "build_type"
     generators = "cmake"
-    requires = "giflib/5.1.2@%s/%s" % (username, channel)
+    requires = "giflib/5.1.3@%s/%s" % (username, channel)
     export = "cat-small.static.gif"
 
     def build(self):


### PR DESCRIPTION
This doesn't address windows - I don't know where you found that zip file. 

giflib 5.1.2 is completely broken, and cannot read gifs without a zeroed heap. 5.1.3 seems to work much better.

http://stackoverflow.com/questions/36292992/is-giflib-5-1-2-not-thread-safe/36294252#36294252
